### PR TITLE
Add Pagination Option

### DIFF
--- a/src/common/store.ts
+++ b/src/common/store.ts
@@ -10,6 +10,7 @@ export type SchemaType = {
   demo_path?: string;
   setup_completed: boolean;
   auto_prec: boolean;
+  pagination: boolean;
 };
 
 const schema: Schema<SchemaType> = {
@@ -25,6 +26,10 @@ const schema: Schema<SchemaType> = {
     default: false,
   },
   auto_prec: {
+    type: "boolean",
+    default: false,
+  },
+  pagination: {
     type: "boolean",
     default: false,
   },

--- a/src/renderer/MainView/DemoTable.tsx
+++ b/src/renderer/MainView/DemoTable.tsx
@@ -7,6 +7,7 @@ import merge from "deepmerge";
 import { ArrowDownward } from "@mui/icons-material";
 import { blue } from "@mui/material/colors";
 
+import useStore from "../hooks/useStore";
 import Demo from "../Demo";
 import loading from "../../../assets/loading.gif";
 import { formatFileSize, formatPlaybackTime } from "../util";
@@ -116,6 +117,7 @@ type DemoTableProps = {
 
 export default function DemoTable(props: DemoTableProps) {
   const { data, viewDemo } = props;
+  const [pagination] = useStore("pagination");
 
   return (
     <>
@@ -133,11 +135,21 @@ export default function DemoTable(props: DemoTableProps) {
           </div>
         }
         sortIcon={<ArrowDownward />}
+        pagination={pagination}
+        paginationPerPage={50}
+        paginationRowsPerPageOptions={[10, 20, 50, 100]}
+        paginationResetDefaultPage
         pointerOnHover
         onRowClicked={viewDemo}
         fixedHeader
-        // 64px is the height of the app bar, 57px is the height of the header.
-        fixedHeaderScrollHeight="calc(100vh - (64px + 57px))"
+        // 64px: height of the app bar
+        // 57px: height of the header
+        // 56px: height of pagination options
+        fixedHeaderScrollHeight={
+          pagination
+            ? "calc(100vh - (64px + 57px + 56px))"
+            : "calc(100vh - (64px + 57px))"
+        }
         progressComponent={
           <div
             style={{

--- a/src/renderer/SettingsView.tsx
+++ b/src/renderer/SettingsView.tsx
@@ -16,6 +16,7 @@ import {
   Palette as PaletteIcon,
   ArrowBackIosNew as ArrowBackIcon,
   UploadFile as UploadFileIcon,
+  MenuBook,
 } from "@mui/icons-material";
 
 import getDemoPath from "./GetDemoPath";
@@ -36,6 +37,7 @@ export default function SettingsView() {
 
   const [demoPath, setDemoPath] = useStore("demo_path");
   const [autoPrec, setAutoPrec] = useStore("auto_prec");
+  const [pagination, setPagination] = useStore("pagination");
 
   const savePath = (newPath: string) => {
     setDemoPath(newPath);
@@ -109,6 +111,19 @@ export default function SettingsView() {
               <Switch
                 onChange={() => setAutoPrec(!autoPrec)}
                 checked={autoPrec}
+              />
+            </ListItem>
+            <ListItem button onClick={() => setPagination(!pagination)}>
+              <ListItemIcon>
+                <MenuBook />
+              </ListItemIcon>
+              <ListItemText
+                primary="Pagination"
+                secondary={pagination ? "on" : "off"}
+              />
+              <Switch
+                onChange={() => setPagination(!pagination)}
+                checked={pagination}
               />
             </ListItem>
           </List>


### PR DESCRIPTION
This PR adds a new setting that allows users to enable pagination to the main demo view. This improves performance greatly for users with several demos (like me with 1000+). When enabled, it defaults to 50 demos per page but is configurable using the dropdown option at the bottom of the page.

Open to any feedback you've got and willing to adjust the defaults, paging options, etc. as needed.

If this PR is helpful, I'd love a `hacktoberfest-accepted` tag on this PR to help aid my open source contributes this month for Hacktoberfest!

## Screenshots

![New option on Settings screen](https://user-images.githubusercontent.com/25459801/193712722-32df9b0d-36c1-4075-bd91-9f290c7a14b0.png)

![New paginated view](https://user-images.githubusercontent.com/25459801/193712751-89c6773f-f65b-4cf6-94f7-b370f0d826ed.png)
