### PR TITLE
[Draft] Add search filters to demo timelines

### DIFF
--- a/src/views/demoDetails/Highlights.tsx
+++ b/src/views/demoDetails/Highlights.tsx
@@ -1,19 +1,67 @@
-import { useMemo, useRef } from "react";
+import { useMemo, useRef, useState } from "react";
 
 import AutoSizer from "react-virtualized-auto-sizer";
 import { FixedSizeList } from "react-window";
 
 import { ScrollArea, Text } from "@mantine/core";
 
-import { GameSummary, UserId, PlayerSummary } from "../../demo";
+import { GameSummary, UserId, PlayerSummary, Highlight, HighlightPlayerSnapshot } from "../../demo";
 import HighlightBox from "./HighlightBox";
+import TimelineFilters, { Filters } from "./TimelineFilters";
 
 export type TimelineProps = {
   gameSummary: GameSummary;
 };
 
+function samePlayer(
+  playerId: number,
+  player: PlayerSummary | HighlightPlayerSnapshot | null
+): boolean {
+  return playerId === player?.user_id;
+}
+
+function doesHighlightIncludePlayer(
+  highlight: Highlight,
+  playerId: number
+): boolean {
+  switch (highlight.t) {
+    case "Airshot":
+      return (
+        samePlayer(playerId, highlight.c.victim) ||
+        samePlayer(playerId, highlight.c.attacker)
+      );
+    case "ChatMessage":
+      return samePlayer(playerId, highlight.c.sender);
+    case "CrossbowAirshot":
+      return (
+        samePlayer(playerId, highlight.c.healer) ||
+        samePlayer(playerId, highlight.c.target)
+      );
+    case "Kill":
+      return (
+        samePlayer(playerId, highlight.c.killer) ||
+        samePlayer(playerId, highlight.c.assister) ||
+        samePlayer(playerId, highlight.c.victim)
+      );
+    case "KillStreak":
+      return samePlayer(playerId, highlight.c.player);
+    case "KillStreakEnded":
+      return (
+        samePlayer(playerId, highlight.c.killer) ||
+        samePlayer(playerId, highlight.c.victim)
+      );
+    case "PlayerConnected":
+      return playerId === highlight.c.user_id;
+    case "PlayerDisconnected":
+      return playerId === highlight.c.user_id;
+    default:
+      return true;
+  }
+}
+
 export default function HighlightsList({ gameSummary }: TimelineProps) {
   const listRef = useRef<FixedSizeList>(null);
+  const [highlights, setHighlights] = useState(gameSummary.highlights);
 
   const playerMap = useMemo(() => {
     const result = new Map<UserId, PlayerSummary>();
@@ -23,46 +71,80 @@ export default function HighlightsList({ gameSummary }: TimelineProps) {
     return result;
   }, [gameSummary.players]);
 
+  const recomputeHighlights = (filters: Filters) => {
+    let highlights = gameSummary.highlights;
+    if (filters.playerIds.length > 0) {
+      highlights = highlights.filter(h => filters.playerIds.find(p => doesHighlightIncludePlayer(h.event, Number.parseInt(p, 10))));
+    }
+    if (filters.chatSearch !== "") {
+      // Search chat messages for matches (case-insensitive) for player names or text content
+      const regex = new RegExp(filters.chatSearch, "i");
+      highlights = highlights.filter(h => h.event.t !== "ChatMessage" || regex.test(h.event.c.sender.name) || regex.test(h.event.c.text));
+    }
+    if (!filters.visibleKillfeed) {
+      highlights = highlights.filter(h => h.event.t !== "Kill" && h.event.t !== "PointCaptured");
+    }
+    if (!filters.visibleChat) {
+      highlights = highlights.filter(h => h.event.t !== "ChatMessage");
+    }
+    if (!filters.visibleConnectionMessages) {
+      highlights = highlights.filter(h => !(h.event.t === "PlayerConnected" || h.event.t === "PlayerDisconnected"));
+    }
+    if (!filters.visibleKillstreaks) {
+      highlights = highlights.filter(h => !(h.event.t === "KillStreak" || h.event.t === "KillStreakEnded"));
+    }
+    if (!filters.visibleRounds) {
+      highlights = highlights.filter(h => !(h.event.t === "RoundStart" || h.event.t === "RoundWin" || h.event.t === "RoundStalemate"));
+    }
+
+    setHighlights(highlights);
+  };
+
   return (
-    <AutoSizer>
-      {({ height, width }) => (
-        <ScrollArea
-          style={{ width, height }}
-          onScrollPositionChange={({ y }) => listRef.current?.scrollTo(y)}
-        >
-          <FixedSizeList
-            height={height}
-            width={width}
-            style={{ overflow: "visible" }}
-            itemCount={gameSummary.highlights.length}
-            itemSize={40}
-            ref={listRef}
-          >
-            {({ style, index }) => {
-              const { event, tick } = gameSummary.highlights[index];
-              return (
-                <div
-                  style={{ ...style, display: "flex", alignItems: "center" }}
-                >
-                  <Text
-                    color="dimmed"
-                    size="sm"
-                    style={{
-                      width: "7ch",
-                      fontFamily: "monospace",
-                      textAlign: "right",
-                      paddingRight: 8,
-                    }}
-                  >
-                    {tick}
-                  </Text>
-                  <HighlightBox event={event} playerMap={playerMap} />
-                </div>
-              );
-            }}
-          </FixedSizeList>
-        </ScrollArea>
-      )}
-    </AutoSizer>
+    <div style={{ height: "100%", display: "flex", flexDirection: "column", margin: "auto" }}>
+      <TimelineFilters gameSummary={gameSummary} onChange={recomputeHighlights}/>
+      <div style={{ height: "100%" }}>
+        <AutoSizer>
+          {({ height, width }) => (
+            <ScrollArea
+              style={{ width, height }}
+              onScrollPositionChange={({ y }) => listRef.current?.scrollTo(y)}
+            >
+              <FixedSizeList
+                height={height}
+                width={width}
+                style={{ overflow: "visible" }}
+                itemCount={highlights.length}
+                itemSize={40}
+                ref={listRef}
+              >
+                {({ style, index }) => {
+                  const { event, tick } = highlights[index];
+                  return (
+                    <div
+                      style={{ ...style, display: "flex", alignItems: "center" }}
+                    >
+                      <Text
+                        color="dimmed"
+                        size="sm"
+                        style={{
+                          width: "7ch",
+                          fontFamily: "monospace",
+                          textAlign: "right",
+                          paddingRight: 8,
+                        }}
+                      >
+                        {tick}
+                      </Text>
+                      <HighlightBox event={event} playerMap={playerMap} />
+                    </div>
+                  );
+                }}
+              </FixedSizeList>
+            </ScrollArea>
+          )}
+        </AutoSizer>
+      </div>
+    </div>
   );
 }

--- a/src/views/demoDetails/TimelineFilters.tsx
+++ b/src/views/demoDetails/TimelineFilters.tsx
@@ -1,0 +1,97 @@
+import { useState } from "react";
+import { MultiSelect, Switch, TextInput } from "@mantine/core";
+import { useToggle } from "@mantine/hooks";
+import { GameSummary, PlayerSummary } from "../../demo";
+
+export type Filters = {
+  playerIds: string[],
+  chatSearch: string,
+  visibleKillfeed: boolean,
+  visibleChat: boolean,
+  visibleConnectionMessages: boolean,
+  visibleKillstreaks: boolean,
+  visibleRounds: boolean,
+};
+
+export type TimelineFiltersProps = {
+  gameSummary: GameSummary;
+  onChange: (values: Filters) => void;
+};
+
+type SelectItem = {
+  label: string;
+  value: string;
+};
+
+function playerToSelectItem(player: PlayerSummary): SelectItem {
+  return {
+    label: player.name,
+    value: player.user_id.toString(10),
+  };
+}
+
+export default function TimelineFilters({
+  gameSummary,
+  onChange,
+}: TimelineFiltersProps) {
+  const [filters, setFilters] = useState({
+    playerIds: [],
+    chatSearch: "",
+    visibleKillfeed: true,
+    visibleChat: true,
+    visibleConnectionMessages: true,
+    visibleKillstreaks: true,
+    visibleRounds: true,
+  } as Filters);
+
+  const [regex, toggleRegex] = useToggle([true, false]);
+
+  return (
+    <div style={{ display: "grid" }}>
+      <Switch label={"Show Killfeed"} defaultChecked={true} onChange={(event) =>{
+        filters.visibleKillfeed = event.target.checked;
+        setFilters(filters);
+        onChange(filters);
+      }}/>
+      <Switch label={"Show Chat"} defaultChecked={true} onChange={(event) => {
+        filters.visibleChat = event.target.checked;
+        setFilters(filters);
+        onChange(filters);
+      }}/>
+      <Switch label={"Show Connection Messages"} defaultChecked={true} onChange={(event) => {
+        filters.visibleConnectionMessages = event.target.checked;
+        setFilters(filters);
+        onChange(filters);
+      }} />
+      <Switch label={"Show Killstreaks"} defaultChecked={true} onChange={(event) => {
+        filters.visibleKillstreaks = event.target.checked;
+        setFilters(filters);
+        onChange(filters);
+      }} />
+      <Switch label={"Show Rounds"} defaultChecked={true} onChange={(event) => {
+        filters.visibleRounds = event.target.checked;
+        setFilters(filters);
+        onChange(filters);
+      }} />
+      <TextInput
+        label={"Search Chat"}
+        placeholder={"Chat search.  Case insensitive; regex supported"}
+        onChange={(event) => {
+        filters.chatSearch = event.target.value;
+        setFilters(filters);
+        onChange(filters);
+      }} />
+      <MultiSelect
+        label={"Filter players"}
+        data={gameSummary.players.map(playerToSelectItem)}
+        placeholder={"Select one or more players"}
+        onChange={(values) => {
+          filters.playerIds = values;
+          setFilters(filters);
+          onChange(filters);
+        }}
+        searchable
+      />
+    </div>
+  );
+}


### PR DESCRIPTION
Adds:
- Toggles to hide or show different highlights in the timeline (chat, killfeed, etc)
- Chat search (only show chat messages matching the input)
- Player search (only show events relevant to the selected players)

TODO:
- [ ] Fix UI bugs (scroll bars sometimes don't fit the list, and the player search box can show the dropdown without clicking on it)
- [ ] Add more filters (eg point captures, airshots)
- [ ] Improve search filter layout
  - [ ] Make search pane expandable to reduce used space (or, maybe shift it to the side of the timeline?)
  - [ ] Make toggle switches not take up so much vertical space
- [ ] Code cleanup pass

## Video demo

https://user-images.githubusercontent.com/121571694/213338776-4484bc0f-e3e7-4bb5-8017-53e55af119cc.mp4

